### PR TITLE
Move ambient status to edge-rendered weather/time

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,12 @@
 
 <body>
 
+<div class="ambient-status" aria-live="polite">
+	<span class="ambient-weather">Weather offline</span>
+	<span class="ambient-divider" aria-hidden="true">•</span>
+	<span class="ambient-time">--:--</span>
+</div>
+
 <section>
 	<header>
 		<h1>Jordan Borth</h1>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[[edge_functions]]
+function = "ambient-status"
+path = "/*"

--- a/netlify/edge-functions/ambient-status.ts
+++ b/netlify/edge-functions/ambient-status.ts
@@ -1,0 +1,83 @@
+type WeatherCodes = {
+	codes: number[];
+	label: string;
+};
+
+const weatherCodes: WeatherCodes[] = [
+	{ codes: [0], label: "Clear" },
+	{ codes: [1], label: "Mostly clear" },
+	{ codes: [2], label: "Partly cloudy" },
+	{ codes: [3], label: "Overcast" },
+	{ codes: [45, 48], label: "Foggy" },
+	{ codes: [51, 53, 55], label: "Drizzle" },
+	{ codes: [56, 57], label: "Freezing drizzle" },
+	{ codes: [61, 63, 65], label: "Rain" },
+	{ codes: [66, 67], label: "Freezing rain" },
+	{ codes: [71, 73, 75, 77], label: "Snow" },
+	{ codes: [80, 81, 82], label: "Rain showers" },
+	{ codes: [85, 86], label: "Snow showers" },
+	{ codes: [95, 96, 99], label: "Thunderstorms" },
+];
+
+const mapWeatherCode = (code: number) => {
+	const match = weatherCodes.find((entry) => entry.codes.includes(code));
+	return match ? match.label : "Weather";
+};
+
+const formatLocalTime = (timezone: string | undefined) => {
+	const formatter = new Intl.DateTimeFormat("en-US", {
+		hour: "numeric",
+		minute: "2-digit",
+		timeZone: timezone,
+	});
+	return formatter.format(new Date());
+};
+
+export default async (request: Request, context: any) => {
+	const response = await context.next();
+	const geo = context?.geo ?? {};
+	const latitude = geo.latitude;
+	const longitude = geo.longitude;
+	const timezone = geo.timezone;
+	const locationLabel = geo.city || "Nearby";
+
+	if (!latitude || !longitude) {
+		return response;
+	}
+
+	const url = new URL("https://api.open-meteo.com/v1/forecast");
+	url.searchParams.set("latitude", latitude);
+	url.searchParams.set("longitude", longitude);
+	url.searchParams.set("current", "temperature_2m,weather_code");
+	url.searchParams.set("temperature_unit", "celsius");
+	url.searchParams.set("timezone", "auto");
+
+	let weatherText = "Weather unavailable";
+	try {
+		const weatherResponse = await fetch(url.toString());
+		if (weatherResponse.ok) {
+			const data = await weatherResponse.json();
+			const temperature = Math.round(data.current.temperature_2m);
+			const condition = mapWeatherCode(data.current.weather_code);
+			const label = locationLabel ? ` · ${locationLabel}` : "";
+			weatherText = `${condition} ${temperature}°C${label}`;
+		}
+	} catch (error) {
+		weatherText = "Weather unavailable";
+	}
+
+	const timeText = formatLocalTime(timezone);
+
+	return new HTMLRewriter()
+		.on(".ambient-weather", {
+			element(element) {
+				element.setInnerContent(weatherText);
+			},
+		})
+		.on(".ambient-time", {
+			element(element) {
+				element.setInnerContent(timeText);
+			},
+		})
+		.transform(response);
+};

--- a/style.css
+++ b/style.css
@@ -32,6 +32,26 @@ body {
 	margin: 0 auto;
 }
 
+.ambient-status {
+	position: fixed;
+	top: 24px;
+	right: 24px;
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+	font-size: 1.3rem;
+	letter-spacing: 0.02em;
+	opacity: 0.55;
+}
+
+.ambient-status span {
+	white-space: nowrap;
+}
+
+.ambient-divider {
+	opacity: 0.6;
+}
+
 a {
 	cursor: pointer;
 	color: inherit;
@@ -204,6 +224,12 @@ footer {
 @media screen and (max-width:450px) {
   body {
     padding: 30px 20px;
+  }
+
+  .ambient-status {
+  	position: static;
+  	margin-bottom: 2.4rem;
+  	justify-content: flex-start;
   }
   
   ul li {


### PR DESCRIPTION
### Motivation
- Replace client-side time/weather polling with a server-side injection so the widget works without browser JavaScript.
- Use edge-provided geolocation to produce lightweight, privacy-focused localized output without requesting precise addresses in the browser.
- Keep a simple static fallback when edge data is not available so the UI remains stable.

### Description
- Removed the client-side ambient JS and left a static fallback in `index.html` (`Weather offline` / `--:--`).
- Added an edge function at `netlify/edge-functions/ambient-status.ts` that reads `context.geo`, fetches Open‑Meteo, formats the time and maps weather codes, and uses `HTMLRewriter` to replace `.ambient-weather` and `.ambient-time` in responses.
- Configured Netlify edge routing with `netlify.toml` to run the function on `/*`.
- Added styling for `.ambient-status` to `style.css` to preserve the intended layout and responsive behavior.

### Testing
- Launched a local static server with `python -m http.server 8000` and served the modified site successfully.
- Captured a visual smoke-test screenshot with Playwright saved as `artifacts/ambient-status-server.png`, which completed successfully.
- No unit or automated edge-integration tests were run in this rollout, so the edge function behavior has not been exercised in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961b11d8ae8832db5e80f83f205a3d1)