### PR TITLE
Add subtle local time and weather footer status

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,7 +55,86 @@
 </section>
 
 <footer>
-	&#8220;People often overlook design that overlooks people&#8221;
+	<p class="footer-quote">&#8220;People often overlook design that overlooks people&#8221;</p>
+	<div class="site-status" role="status" aria-live="polite">
+		<span class="status-location">Vancouver</span>
+		<span class="status-separator">•</span>
+		<span class="status-time" data-status-time>--:--</span>
+		<span class="status-separator">•</span>
+		<span class="status-weather" data-status-weather>--</span>
+	</div>
 </footer>
+<script>
+	const locationLabel = "Vancouver";
+	const latitude = 49.2827;
+	const longitude = -123.1207;
+	const timeZone = "America/Vancouver";
+	const timeFormatter = new Intl.DateTimeFormat("en-CA", {
+		timeZone,
+		hour: "2-digit",
+		minute: "2-digit",
+	});
+	const weatherCodeMap = new Map([
+		[0, "Clear"],
+		[1, "Mostly clear"],
+		[2, "Partly cloudy"],
+		[3, "Overcast"],
+		[45, "Fog"],
+		[48, "Rime fog"],
+		[51, "Light drizzle"],
+		[53, "Drizzle"],
+		[55, "Heavy drizzle"],
+		[61, "Light rain"],
+		[63, "Rain"],
+		[65, "Heavy rain"],
+		[71, "Light snow"],
+		[73, "Snow"],
+		[75, "Heavy snow"],
+		[80, "Rain showers"],
+		[81, "Heavy showers"],
+		[82, "Violent showers"],
+		[95, "Thunderstorm"],
+	]);
+	const timeElement = document.querySelector("[data-status-time]");
+	const weatherElement = document.querySelector("[data-status-weather]");
+	const locationElement = document.querySelector(".status-location");
+
+	locationElement.textContent = locationLabel;
+
+	const updateTime = () => {
+		timeElement.textContent = timeFormatter.format(new Date());
+	};
+
+	const updateWeather = async () => {
+		const url = new URL("https://api.open-meteo.com/v1/forecast");
+		url.search = new URLSearchParams({
+			latitude,
+			longitude,
+			current: "temperature_2m,weather_code",
+			temperature_unit: "celsius",
+			timezone: timeZone,
+		}).toString();
+
+		try {
+			const response = await fetch(url);
+			if (!response.ok) {
+				throw new Error("Weather request failed");
+			}
+
+			const data = await response.json();
+			const temperature = Math.round(data.current.temperature_2m);
+			const description = weatherCodeMap.get(data.current.weather_code) ?? "Clear";
+
+			weatherElement.textContent = `${temperature}°C ${description}`;
+		} catch (error) {
+			weatherElement.textContent = "Weather unavailable";
+		}
+	};
+
+	updateTime();
+	updateWeather();
+	setInterval(updateTime, 60 * 1000);
+	setInterval(updateWeather, 30 * 60 * 1000);
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
 		<span class="status-location">Vancouver</span>
 		<span class="status-separator">•</span>
 		<span class="status-time" data-status-time>--:--</span>
+		<span class="status-timezone" data-status-timezone>PT</span>
 		<span class="status-separator">•</span>
 		<span class="status-weather" data-status-weather>--</span>
 	</div>
@@ -69,6 +70,7 @@
 	const latitude = 49.2827;
 	const longitude = -123.1207;
 	const timeZone = "America/Vancouver";
+	const timeZoneLabel = "PT";
 	const timeFormatter = new Intl.DateTimeFormat("en-CA", {
 		timeZone,
 		hour: "2-digit",
@@ -98,8 +100,10 @@
 	const timeElement = document.querySelector("[data-status-time]");
 	const weatherElement = document.querySelector("[data-status-weather]");
 	const locationElement = document.querySelector(".status-location");
+	const timeZoneElement = document.querySelector("[data-status-timezone]");
 
 	locationElement.textContent = locationLabel;
+	timeZoneElement.textContent = timeZoneLabel;
 
 	const updateTime = () => {
 		timeElement.textContent = timeFormatter.format(new Date());

--- a/style.css
+++ b/style.css
@@ -133,7 +133,9 @@ hr {
 footer {
   margin-top: 4.0rem;
   margin-bottom: 4.0rem;
-  opacity: .5;
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
 }
 
 /*=========================================
@@ -170,6 +172,20 @@ ul li a {
 
 footer {
 	font-size: 1.6rem;
+}
+
+.footer-quote {
+	opacity: .5;
+}
+
+.site-status {
+	display: inline-flex;
+	gap: 0.6rem;
+	font-size: 1.2rem;
+	letter-spacing: 0.02em;
+	text-transform: uppercase;
+	opacity: .4;
+	align-self: flex-end;
 }
 
 @media (prefers-color-scheme: light) {
@@ -212,6 +228,10 @@ footer {
   
   ul li a {
   	height: 50px;
+  }
+
+  .site-status {
+  	align-self: flex-start;
   }
  
 }


### PR DESCRIPTION
### Motivation
- Provide a subtle, low-cost way to make the site feel more dynamic by showing local time and weather for a fixed location rather than using per-visitor geolocation.
- Keep the implementation simple, performant, and privacy-friendly by embedding a small client-side widget that fetches a public weather API and formats time with the page timezone.

### Description
- Add a small footer status UI with `role="status"` and `aria-live="polite"` that displays a fixed `location`, the current `time`, and a `weather` summary for Vancouver using hard-coded `latitude`/`longitude` and `timeZone`.
- Fetch current weather from the Open-Meteo API (`https://api.open-meteo.com/v1/forecast`) and map weather codes to human-readable labels via an in-script `weatherCodeMap`.
- Use `Intl.DateTimeFormat` with the specified `timeZone` to render the time and update it every minute, while updating the weather every 30 minutes with `setInterval`.
- Update styles in `style.css` to lay out the footer as a compact column, add `.footer-quote` opacity, and add the `.site-status` inline-flex styling with responsive alignment for small screens.

### Testing
- Served the site locally with `python -m http.server 8000` and verified the page loads successfully, which succeeded.
- Captured a headless browser screenshot using a Playwright Python script that loaded `http://127.0.0.1:8000/` and saved `artifacts/weather-time-footer.png`, which completed successfully.
- No unit tests exist for this static/UI change and no additional automated checks were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ea753684832d919a5d6255e5e1a1)