### PR TITLE
Add loading spinner for weather status

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,7 +62,10 @@
 		<span class="status-time" data-status-time>--:--</span>
 		<span class="status-timezone" data-status-timezone>PT</span>
 		<span class="status-separator">•</span>
-		<span class="status-weather" data-status-weather>--</span>
+		<span class="status-weather" data-status-weather>
+			<span class="loading-spinner" aria-hidden="true"></span>
+			<span class="sr-only">Loading weather</span>
+		</span>
 	</div>
 </footer>
 <script>

--- a/style.css
+++ b/style.css
@@ -188,6 +188,38 @@ footer {
 	align-self: flex-end;
 }
 
+.status-weather {
+	display: inline-flex;
+	align-items: center;
+}
+
+.loading-spinner {
+	width: 0.9rem;
+	height: 0.9rem;
+	border-radius: 50%;
+	border: 2px solid currentColor;
+	border-right-color: transparent;
+	animation: spinner 0.9s linear infinite;
+}
+
+.sr-only {
+	border: 0;
+	clip: rect(0 0 0 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}
+
+@keyframes spinner {
+	to {
+		transform: rotate(360deg);
+	}
+}
+
 @media (prefers-color-scheme: light) {
 	body {
 		color: #0f0f0f;


### PR DESCRIPTION
### Motivation

- Provide a visual indicator while the weather request is in-flight instead of a static placeholder.
- Improve accessibility by announcing the loading state to assistive technologies using an offscreen label. 
- Keep the footer layout stable while the site populates live weather information.

### Description

- Replace the `data-status-weather` placeholder in `index.html` with a `loading-spinner` element and an accessible `sr-only` label. 
- Add styles to `style.css` for `.status-weather`, `.loading-spinner`, `.sr-only`, and the `@keyframes spinner` animation using `currentColor`. 
- Leave the existing weather fetch logic intact so the script updates the `data-status-weather` element once the API response arrives.

### Testing

- Launched a local server with `python -m http.server` and captured a page screenshot via Playwright which succeeded and produced `artifacts/weather-spinner.png`.
- An initial Playwright JS invocation failed due to script syntax, but the Python Playwright script run completed successfully. 
- No unit tests were run for this static site change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f23b2fc0832d9647a52b49dc8bed)