### PR TITLE
Footer: Salt Spring Island location, restore quote typography and tertiary separator color

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,8 +70,8 @@
 </footer>
 <script>
 	const locationLabel = "Salt Spring Island";
-	const latitude = 49.2827;
-	const longitude = -123.1207;
+	const latitude = 48.855;
+	const longitude = -123.5;
 	const timeZone = "America/Vancouver";
 	const timeZoneLabel = "PT";
 	const timeFormatter = new Intl.DateTimeFormat("en-CA", {

--- a/style.css
+++ b/style.css
@@ -175,6 +175,9 @@ footer {
 }
 
 .footer-quote {
+	font-size: 1.6rem;
+	line-height: 1.4;
+	margin: 0;
 	opacity: .5;
 }
 
@@ -184,8 +187,12 @@ footer {
 	font-size: 1.2rem;
 	letter-spacing: 0.02em;
 	text-transform: uppercase;
-	opacity: .4;
+	color: rgba(235, 235, 245, 0.6);
 	align-self: flex-end;
+}
+
+.status-separator {
+	color: rgba(235, 235, 245, 0.3);
 }
 
 .status-weather {
@@ -224,6 +231,14 @@ footer {
 	body {
 		color: #0f0f0f;
 		background-color: rgb(251, 251, 251);
+	}
+
+	.site-status {
+		color: rgba(60, 60, 67, 0.6);
+	}
+
+	.status-separator {
+		color: rgba(60, 60, 67, 0.3);
 	}
 	
 	ul li a {


### PR DESCRIPTION
### Motivation
- Replace the Vancouver location with Salt Spring Island as the footer status location and coordinates. 
- Fix the broken footer quote styling so the line-height and spacing match the site's typography. 
- Ensure the separator dot (`•`) uses a tertiary label-style color so it reads as a subtle divider in both color schemes.

### Description
- Updated the location coordinates in `index.html` to Salt Spring Island (`latitude = 48.855`, `longitude = -123.5`) and kept the `locationLabel` as "Salt Spring Island".
- Restored footer quote typography in `style.css` by adding `font-size`, `line-height`, and `margin` to `.footer-quote`.
- Replaced the previous opacity-based status styling with explicit `color` on `.site-status` and added a `.status-separator` rule to apply a tertiary color in dark and light modes.
- Added light-mode overrides for `.site-status` and `.status-separator` to ensure consistent tertiary coloring across themes.

### Testing
- Served the site locally with `python -m http.server 8000` and verified rendering in a browser session, which completed successfully. 
- Captured a full-page screenshot using a Playwright script to validate the footer layout and colors, and the script ran successfully and produced an artifact. 
- No unit tests were applicable for these static styling and content updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f485dcf4832d9ea3cd2d72b10c06)