### PR TITLE
Remove timezone label from status footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -60,8 +60,6 @@
 		<span class="status-location">Salt Spring Island</span>
 		<span class="status-separator">•</span>
 		<span class="status-time" data-status-time>--:--</span>
-		<span class="status-timezone" data-status-timezone>PT</span>
-		<span class="status-separator">•</span>
 		<span class="status-weather" data-status-weather>
 			<span class="loading-spinner" aria-hidden="true"></span>
 			<span class="sr-only">Loading weather</span>
@@ -73,7 +71,6 @@
 	const latitude = 48.855;
 	const longitude = -123.5;
 	const timeZone = "America/Vancouver";
-	const timeZoneLabel = "PT";
 	const timeFormatter = new Intl.DateTimeFormat("en-CA", {
 		timeZone,
 		hour: "2-digit",
@@ -103,10 +100,8 @@
 	const timeElement = document.querySelector("[data-status-time]");
 	const weatherElement = document.querySelector("[data-status-weather]");
 	const locationElement = document.querySelector(".status-location");
-	const timeZoneElement = document.querySelector("[data-status-timezone]");
 
 	locationElement.textContent = locationLabel;
-	timeZoneElement.textContent = timeZoneLabel;
 
 	const updateTime = () => {
 		timeElement.textContent = timeFormatter.format(new Date());


### PR DESCRIPTION
### Motivation
- Remove the timezone label from the footer status and eliminate the now-unused script binding to simplify the UI.
- Avoid showing a static timezone abbreviation (`PT`) that could be misleading or unnecessary.

### Description
- Remove the `<span class="status-timezone" data-status-timezone>PT</span>` and the adjacent separator from `index.html`.
- Drop the `timeZoneLabel` constant and the `document.querySelector("[data-status-timezone]")` lookup and assignment from the footer script in `index.html`.
- Preserve `timeZone` and the `timeFormatter` so the time display and weather fetch behavior remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961fade2d6c832db125b22d46236224)