### PR TITLE
Update contact buttons (SVG + two-tone) and add status separator

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,11 +46,41 @@
   
 <hr />
   
-<ul>
-<li><a href="mailto:jordan@borth.ca" title="Email">Email</a></li>
-<li><a href="https://mastodon.social/@jordanborth" rel="me" title="Mastodon">Mastodon</a></li>
-<li><a href="https://twitter.com/jordanborth" title="Twitter">Twitter</a></li>
-<li><a href="https://read.cv/jordanborth" title="Read.cv">Read.cv</a></li>
+<ul class="contact-links">
+<li>
+	<a href="mailto:jordan@borth.ca" title="Email">
+		<span class="contact-icon" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M4 6h16a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z"></path>
+				<path d="m22 8-10 6L2 8"></path>
+			</svg>
+		</span>
+		<span>Email</span>
+	</a>
+</li>
+<li>
+	<a href="https://mastodon.social/@jordanborth" rel="me" title="Mastodon">
+		<span class="contact-icon" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M7 3h10a4 4 0 0 1 4 4v5.5c0 3.6-2.4 6.2-6.1 6.8-1.2.2-2.3.2-3.6 0-1.4-.2-2.7-.7-3.7-1.4v2.1c0 1-.8 2-1.8 2H4.3a.5.5 0 0 1-.5-.5V7a4 4 0 0 1 4-4Z"></path>
+				<path d="M8.5 8v5"></path>
+				<path d="M15.5 8v5"></path>
+				<path d="M8.5 12c0-1.4 1.1-2.5 2.5-2.5h2c1.4 0 2.5 1.1 2.5 2.5"></path>
+			</svg>
+		</span>
+		<span>Mastodon</span>
+	</a>
+</li>
+<li>
+	<a href="https://twitter.com/jordanborth" title="X">
+		<span class="contact-icon" aria-hidden="true">
+			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
+				<path d="M5 4h4.6l3 4.4L17.4 4H21l-6.9 7.6L21 20h-4.6l-3.4-5-4 5H5l7.5-8.4L5 4Z"></path>
+			</svg>
+		</span>
+		<span>X</span>
+	</a>
+</li>
 </ul>
 </section>
 
@@ -60,6 +90,7 @@
 		<span class="status-location">Salt Spring Island</span>
 		<span class="status-separator">•</span>
 		<span class="status-time" data-status-time>--:--</span>
+		<span class="status-separator">•</span>
 		<span class="status-weather" data-status-weather>
 			<span class="loading-spinner" aria-hidden="true"></span>
 			<span class="sr-only">Loading weather</span>

--- a/style.css
+++ b/style.css
@@ -53,9 +53,10 @@ ul li {
 
 ul li a {
   color: inherit;
-  background: rgba(255, 255, 255, .2);
+  background: linear-gradient(135deg, #252525, #1f1f1f);
  display: -ms-flexbox;
  display: flex;
+	gap: 0.8rem;
 	border-bottom: none;
  -webkit-box-align: center;
  -ms-flex-align: center;
@@ -64,12 +65,25 @@ ul li a {
  -ms-flex-pack: center;
  justify-content: center;
  text-decoration: none;
- border-radius: 8px;
+ border-radius: 14px;
+ border: 1px solid rgba(255, 255, 255, 0.06);
  -webkit-transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),-webkit-transform .2s cubic-bezier(.5,.1,0,1.2);
  transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),-webkit-transform .2s cubic-bezier(.5,.1,0,1.2);
  transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),transform .2s cubic-bezier(.5,.1,0,1.2);
  transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),transform .2s cubic-bezier(.5,.1,0,1.2),-webkit-transform .2s cubic-bezier(.5,.1,0,1.2);
  padding: .8rem 1.8rem;
+}
+
+.contact-links .contact-icon {
+	display: inline-flex;
+	width: 1.6rem;
+	height: 1.6rem;
+	color: rgba(255, 255, 255, 0.8);
+}
+
+.contact-links .contact-icon svg {
+	width: 100%;
+	height: 100%;
 }
 
 a[title="Quill.Chat"] {
@@ -96,22 +110,17 @@ a[title="Twitter-aquisition"]:hover {
 
 a[title="Email"]:hover {
 	color: #1b1b1b;
-	background: rgba(255, 255, 255, 1) ;
+	background: linear-gradient(135deg, #ffffff, #d9d9d9);
 }
 
-a[title="Read.cv"]:hover {
-	color: #1b1b1b;
-	background: rgba(255, 255, 255, 1) ;
-}
-
-a[title="Twitter"]:hover {
+a[title="X"]:hover {
 	color: white;
-	background: #1da1f2;
+	background: linear-gradient(135deg, #2e2e2e, #0f0f0f);
 }
 
 a[title="Mastodon"]:hover {
 	color: white;
-	background: #595aff;
+	background: linear-gradient(135deg, #6b6bff, #3d3fbf);
 }
 
 a[title="Dribbble"]:hover {
@@ -241,25 +250,26 @@ footer {
 	}
 	
 	ul li a {
-	  background: rgba(0,0,0, .05);
+	  background: linear-gradient(135deg, #f0f0f0, #e3e3e3);
+	  border: 1px solid rgba(0, 0, 0, 0.06);
 	}
 	
 	hr {
 		background-color: rgba(0,0,0,.1);
 	}
 	
-	a[title="Email"]:hover, a[title="Read.cv"]:hover  {
+	a[title="Email"]:hover  {
 		color: #f1f1f1;
-		background: rgba(0,0,0, .5) ;
+		background: linear-gradient(135deg, #1f1f1f, #0f0f0f);
 	}
 	
 	a[title="Quill.Chat"], a {
 		border-bottom: 1px solid rgba(0,0,0,.1);
 	}
-	
-	
-	
-	
+
+	.contact-links .contact-icon {
+		color: rgba(15, 15, 15, 0.7);
+	}
 }
 
 


### PR DESCRIPTION
### Motivation
- Fix the missing separator between the time and weather in the footer status display.
- Improve the contact buttons’ visual hierarchy by using two-tone backgrounds and a slightly darker surface to contrast with the page background.
- Use modern inline SVG icons, increase corner radius for buttons, rename the Twitter link to `X`, and remove the `Read.cv` link.

### Description
- Replace the contact links block in `index.html` with a `ul.contact-links` list that embeds inline SVG icons and removes the `Read.cv` entry while renaming the Twitter link to `X`.
- Insert an additional `<span class="status-separator">•</span>` between the time and weather in `index.html` to restore the missing separator.
- Update `style.css` to restyle contact buttons with two-tone `linear-gradient` backgrounds, a larger `border-radius: 14px`, a subtle border, and added `gap` between icon and label.
- Add `.contact-links .contact-icon` sizing and SVG rules plus hover treatments for `a[title="X"]`, `a[title="Mastodon"]`, and light-mode background adjustments.

### Testing
- Launched a static server with `python -m http.server 8000` to serve the site, which started successfully.
- Rendered the page headlessly using a Playwright script and captured `artifacts/contact-buttons.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961fd7b7634832d8d21b1a250e43e1c)