### PR TITLE
Swap social icons to Griddy Icons and remove button borders

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,10 +50,7 @@
 <li>
 	<a href="mailto:jordan@borth.ca" title="Email">
 		<span class="contact-icon" aria-hidden="true">
-			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-				<path d="M4 6h16a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2Z"></path>
-				<path d="m22 8-10 6L2 8"></path>
-			</svg>
+			<img src="https://griddyicons.com/icons/mail.svg" alt="" loading="lazy">
 		</span>
 		<span>Email</span>
 	</a>
@@ -61,12 +58,7 @@
 <li>
 	<a href="https://mastodon.social/@jordanborth" rel="me" title="Mastodon">
 		<span class="contact-icon" aria-hidden="true">
-			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-				<path d="M7 3h10a4 4 0 0 1 4 4v5.5c0 3.6-2.4 6.2-6.1 6.8-1.2.2-2.3.2-3.6 0-1.4-.2-2.7-.7-3.7-1.4v2.1c0 1-.8 2-1.8 2H4.3a.5.5 0 0 1-.5-.5V7a4 4 0 0 1 4-4Z"></path>
-				<path d="M8.5 8v5"></path>
-				<path d="M15.5 8v5"></path>
-				<path d="M8.5 12c0-1.4 1.1-2.5 2.5-2.5h2c1.4 0 2.5 1.1 2.5 2.5"></path>
-			</svg>
+			<img src="https://griddyicons.com/icons/mastodon.svg" alt="" loading="lazy">
 		</span>
 		<span>Mastodon</span>
 	</a>
@@ -74,9 +66,7 @@
 <li>
 	<a href="https://twitter.com/jordanborth" title="X">
 		<span class="contact-icon" aria-hidden="true">
-			<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round">
-				<path d="M5 4h4.6l3 4.4L17.4 4H21l-6.9 7.6L21 20h-4.6l-3.4-5-4 5H5l7.5-8.4L5 4Z"></path>
-			</svg>
+			<img src="https://griddyicons.com/icons/x.svg" alt="" loading="lazy">
 		</span>
 		<span>X</span>
 	</a>

--- a/style.css
+++ b/style.css
@@ -66,7 +66,6 @@ ul li a {
  justify-content: center;
  text-decoration: none;
  border-radius: 14px;
- border: 1px solid rgba(255, 255, 255, 0.06);
  -webkit-transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),-webkit-transform .2s cubic-bezier(.5,.1,0,1.2);
  transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),-webkit-transform .2s cubic-bezier(.5,.1,0,1.2);
  transition: background-color .2s cubic-bezier(.78,0,.174,1),color .2s cubic-bezier(.78,0,.174,1),transform .2s cubic-bezier(.5,.1,0,1.2);
@@ -84,6 +83,12 @@ ul li a {
 .contact-links .contact-icon svg {
 	width: 100%;
 	height: 100%;
+}
+
+.contact-links .contact-icon img {
+	width: 100%;
+	height: 100%;
+	display: block;
 }
 
 a[title="Quill.Chat"] {
@@ -251,7 +256,6 @@ footer {
 	
 	ul li a {
 	  background: linear-gradient(135deg, #f0f0f0, #e3e3e3);
-	  border: 1px solid rgba(0, 0, 0, 0.06);
 	}
 	
 	hr {


### PR DESCRIPTION
### Motivation
- Replace the existing inline SVG social icons with Griddy Icons assets for improved visuals.
- Remove the visible borders on the social buttons to match the requested cleaner look.

### Description
- Replaced inline SVG markup for Email, Mastodon and X with `<img src="https://griddyicons.com/icons/...">` tags in `index.html`.
- Removed the `border: 1px solid ...` rule from the main social button selector in `style.css` and from the light-theme variant.
- Added `.contact-links .contact-icon img` CSS to size and display the external icon images consistently.
- Kept hover/background color behaviors intact so button interactions remain unchanged.

### Testing
- Started a local server with `python -m http.server 8000` and captured a visual check screenshot via Playwright which succeeded and produced `artifacts/social-icons.png`.
- Attempted automated `curl` requests to `griddyicons.com` which returned HTTP 403, so remote asset availability could not be validated by the runner.
- No unit tests exist for these static HTML/CSS changes, and no additional automated test suite was run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962010508f0832daeaf2f1d7a5b94f9)